### PR TITLE
patch to fix data loss during manage categories activity

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlynotes/ui/ManageCategoriesActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlynotes/ui/ManageCategoriesActivity.java
@@ -107,6 +107,32 @@ public class ManageCategoriesActivity extends AppCompatActivity implements View.
         });
     }
 
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        EditText name = (EditText) findViewById(R.id.etName);
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editName", "");
+        } else {
+            spGenEditor.putString("editName", name.getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("MainActivity", MODE_PRIVATE);
+        EditText name = (EditText) findViewById(R.id.etName);
+        name.setText(spGen.getString("editName", ""));
+        isSubmit = false;
+    }
+
     @Override
     public void onClick(View v) {
         switch (v.getId()) {
@@ -117,6 +143,7 @@ public class ManageCategoriesActivity extends AppCompatActivity implements View.
                         Snackbar.make(name,R.string.toast_category_exists, Snackbar.LENGTH_SHORT).show();
                     }
                     name.setText("");
+                    isSubmit = true;
                 }
                 updateList();
                 break;


### PR DESCRIPTION
Hello developers of privacy friendly notes

I am using your app privacy friendly notes. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/yVybm14

When the user tries to add a new category. If the screen focus goes to another app or activity or if the user accidentally closes or press back the app, the user will lose any data they had put into this page

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/cCdw2CG). Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim