### PR TITLE
Update dependency for colorpicker dialog (jcenter is deprecated)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="Android Studio java home" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'com.simplify:ink:1.0.0'
-    implementation 'petrov.kristiyan.colorpicker:colorpicker-library:1.1.0'
+    implementation 'io.github.eltos:simpledialogfragments:3.6.3'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'

--- a/app/src/main/java/org/secuso/privacyfriendlynotes/ui/notes/SketchActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlynotes/ui/notes/SketchActivity.java
@@ -47,6 +47,7 @@ import android.widget.Spinner;
 import android.widget.TimePicker;
 import android.widget.Toast;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -77,18 +78,20 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import petrov.kristiyan.colorpicker.ColorPicker;
+import eltos.simpledialogfragment.SimpleDialog;
+import eltos.simpledialogfragment.color.SimpleColorDialog;
 
 /**
  * Activity that allows to add, edit and delete sketch notes.
  */
 
-public class SketchActivity extends AppCompatActivity implements View.OnClickListener, DatePickerDialog.OnDateSetListener, TimePickerDialog.OnTimeSetListener, PopupMenu.OnMenuItemClickListener {
+public class SketchActivity extends AppCompatActivity implements View.OnClickListener, DatePickerDialog.OnDateSetListener, TimePickerDialog.OnTimeSetListener, PopupMenu.OnMenuItemClickListener, SimpleDialog.OnDialogResultListener {
     public static final String EXTRA_ID = "org.secuso.privacyfriendlynotes.ID";
     public static final String EXTRA_TITLE = "org.secuso.privacyfriendlynotes.TITLE";
     public static final String EXTRA_CONTENT = "org.secuso.privacyfriendlynotes.CONTENT";
     public static final String EXTRA_CATEGORY = "org.secuso.privacyfriendlynotes.CATEGORY";
     public static final String EXTRA_ISTRASH = "org.secuso.privacyfriendlynotes.ISTRASH";
+    public static final String TAG_COLORDIALOG = "org.secuso.privacyfriendlynotes.COLORDIALOG";
 
 
 
@@ -549,17 +552,24 @@ public class SketchActivity extends AppCompatActivity implements View.OnClickLis
     }
 
     private void displayColorDialog() {
-        new ColorPicker(this)
-                .setOnFastChooseColorListener(new ColorPicker.OnFastChooseColorListener() {
-                    @Override
-                    public void setOnFastChooseColorListener(int position, int color) {
-                        drawView.setColor(color);
-                        btnColorSelector.setBackgroundColor(color);
-                    }
-                })
-                .setColors(R.array.mdcolor_500)
-                .setTitle("")
-                .show();
+        SimpleColorDialog.build()
+                .title("")
+                .allowCustom(false)
+                .cancelable(true)//allows close by tapping outside of dialog
+                .colors(this, R.array.mdcolor_500)
+                .choiceMode(SimpleColorDialog.SINGLE_CHOICE_DIRECT)//auto-close on selection
+                .show(this, TAG_COLORDIALOG);
+    }
+
+    @Override
+    public boolean onResult(@NonNull String dialogTag, int which, @NonNull Bundle extras) {
+        if (dialogTag.equals(TAG_COLORDIALOG) && which == BUTTON_POSITIVE){
+            @ColorInt int color = extras.getInt(SimpleColorDialog.COLOR);
+            drawView.setColor(color);
+            btnColorSelector.setBackgroundColor(color);
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     ext.kotlin_version = "1.6.21"
     repositories {
-        jcenter()
         mavenCentral()
         google()
     }
@@ -18,7 +17,6 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         mavenCentral()
         google()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.caching=true


### PR DESCRIPTION
This PR replaces the very old dependency of the colorpicker with a more up-to-date and modern one.
This is because the `jcenter` repo is deprecated and will be soon offline.

The new dependency: [eltos/SimpleDialogFragments](https://github.com/eltos/SimpleDialogFragments/wiki/SimpleColorDialog)